### PR TITLE
updating drawer context to support multiple drawer instances

### DIFF
--- a/src/containers/DrawerItems/DrawerItems.tsx
+++ b/src/containers/DrawerItems/DrawerItems.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import Drawer from 'components/Drawer/Drawer';
 import { CloseIcon } from 'assets/icons/CloseIcon';
 import { useDrawerState, useDrawerDispatch } from 'context/DrawerContext';
+import { useHistory } from 'react-router-dom';
 
 /** Drawer Components */
 import NewBlogForm from '../Blogs/NewBlogForm';
@@ -12,6 +13,8 @@ import ProfileForm from 'containers/Settings/ProfileForm';
 import PostUpdateForm from 'containers/Posts/PostUpdateForm';
 import CredsForm from 'containers/Settings/CredsForm';
 import { CloseButton } from './DrawerItems.style';
+
+export type CloseDrawer = () => void;
 
 const DRAWER_COMPONENTS = {
   BLOG_FORM: NewBlogForm,
@@ -24,18 +27,34 @@ const DRAWER_COMPONENTS = {
 };
 
 export default function DrawerItems() {
+  const history = useHistory();
+
   const isOpen = useDrawerState('isOpen');
   const drawerComponent = useDrawerState('drawerComponent');
   const data = useDrawerState('data');
+  const consumedUrl = useDrawerState('consumedUrl');
+  const newUrl = useDrawerState('newUrl');
   const dispatch = useDrawerDispatch();
 
-  const closeDrawer = useCallback(() => {
+  const closeDrawer: CloseDrawer = useCallback(() => {
     dispatch({ type: 'CLOSE_DRAWER' });
+    dispatch({ type: 'CONSUME_URL_STACK' });
   }, [dispatch]);
-  if (!drawerComponent) {
+
+  useEffect(() => {
+    if (consumedUrl) history.push(consumedUrl);
+  }, [consumedUrl, history]);
+
+  useEffect(() => {
+    if (newUrl) history.push(newUrl);
+  }, [newUrl, history]);
+
+  if (drawerComponent.length === 0) {
     return null;
   }
-  const SpecificContent = DRAWER_COMPONENTS[drawerComponent];
+
+  const SpecificContent =
+    DRAWER_COMPONENTS[drawerComponent[drawerComponent.length - 1]];
 
   return (
     <Drawer

--- a/src/context/DrawerContext.tsx
+++ b/src/context/DrawerContext.tsx
@@ -2,26 +2,40 @@ import { createCtx } from './create-context';
 
 const initialState = {
   isOpen: false,
-  drawerComponent: null,
-  data: null,
+  drawerComponent: [],
+  data: [],
+  urlStack: [],
+  consumedUrl: undefined,
+  newUrl: undefined,
 };
 type State = typeof initialState;
 type Action = any;
 function reducer(state: State, action: Action) {
   switch (action.type) {
     case 'OPEN_DRAWER':
+      const components = [...state.drawerComponent, action.drawerComponent];
       return {
         ...state,
-        isOpen: true,
-        drawerComponent: action.drawerComponent,
-        data: action.data,
+        isOpen: Boolean(components.length),
+        drawerComponent: components,
+        data: [...state.data, action.data],
+        urlStack: [...state.urlStack, action.backUrl],
+        newUrl: action.newUrl,
+        consumedUrl: undefined,
       };
     case 'CLOSE_DRAWER':
       return {
         ...state,
-        isOpen: false,
-        drawerComponent: null,
-        data: null,
+        isOpen: Boolean(state.drawerComponent.slice(0, -1).length),
+        drawerComponent: state.drawerComponent.slice(0, -1),
+        data: state.data.slice(0, -1),
+      };
+    case 'CONSUME_URL_STACK':
+      return {
+        ...state,
+        urlStack: state.urlStack.slice(0, -1),
+        consumedUrl: state.urlStack.pop(),
+        newUrl: undefined,
       };
     default:
       return state;


### PR DESCRIPTION
Pull-Request for `Object Press`

## Description

- Updated DrawerContext and DrawerItems to support multiple instances of drawer
- Updated DrawerContext and DrawerItems to handle url changing instead of pushning new url everytime calling open/ close drawer
- Updated the usages of DrawerContext across the application. (WIP)

## Relates to issue

- #5 

## Reviewers

- @vmcodes (merge duty)
