### PR TITLE
Ensured that search is performed on enter keypress

### DIFF
--- a/src/containers/Gallery/Gallery.tsx
+++ b/src/containers/Gallery/Gallery.tsx
@@ -89,6 +89,10 @@ export default function Posts() {
     setSelectedBlog([]);
   };
 
+  const handleSearchKeyPress = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') handleSearch();
+  };
+
   const handleBlog = async ({ value }) => {
     setImages([]);
     setIsLoading(true);
@@ -166,6 +170,7 @@ export default function Posts() {
                 <Col md={4} lg={5}>
                   <Input
                     value={search}
+                    onKeyPress={handleSearchKeyPress}
                     placeholder="Search By Post Title"
                     onChange={(e) => setSearch(e.target.value)}
                     clearable

--- a/src/containers/Posts/Posts.tsx
+++ b/src/containers/Posts/Posts.tsx
@@ -105,6 +105,10 @@ export default function Posts() {
     setSelectedBlog([]);
   };
 
+  const handleSearchKeyPress = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') handleSearch();
+  };
+
   const handleBlog = async ({ value }) => {
     if (value.length) {
       const posts = ((await dispatch(searchPostsByBlog(value[0].id))) as any)
@@ -199,6 +203,7 @@ export default function Posts() {
                 <Col md={4} lg={5}>
                   <Input
                     value={search}
+                    onKeyPress={handleSearchKeyPress}
                     placeholder="Search By Post Title"
                     onChange={(e) => setSearch(e.target.value)}
                     clearable


### PR DESCRIPTION
Pull-Request for `Object Press`

## Description
Made use of the `onKeyPress` listener on the `Input` tags to check when `Enter` is pressed and trigger search thereafter.

## Relates to issue
-  Add search on enter keypress #8 

## Reviewers
- @vmcodes (merge duty)
